### PR TITLE
Add CI workflow and coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install coverage-badge
+
+      - name: Run tests
+        run: |
+          pytest --cov=src --cov-report=xml --cov-report=term
+
+      - name: Generate coverage badge
+        run: coverage-badge -o coverage.svg -f
+
+      - name: Commit coverage badge
+        if: github.ref == 'refs/heads/main'
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: coverage.svg
+          message: 'chore: update coverage badge'
+          default_author: github_actions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Event Scraper
+[![CI](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml/badge.svg)](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml) [![Coverage](coverage.svg)](coverage.svg)
+
 
 Hacker Newsなどの指定したサイトをスクレイピングして、機械学習モデルから利用できる統一的なデータフォーマットに変換するツールです。
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">66%</text>
+        <text x="80" y="14">66%</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- add CI workflow to run tests and generate coverage badge
- display build status and coverage badges at the top of README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3409966c8326b27893d12bacdca1