### PR TITLE
chore: update CI to Python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update the GitHub Actions test matrix to run against Python 3.12

## Testing
- mypy src *(fails: existing relative import issues in src package)*
- pytest *(fails: network access required for HackerNews connectivity validation test)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4921b048832696458082f0ab1358