### PR TITLE
Fix mypy configuration for third-party imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,20 @@ show_error_codes = true
 strict_optional = true
 plugins = []
 
+[[tool.mypy.overrides]]
+module = [
+  "aiohttp",
+  "aiohttp.*",
+  "bs4",
+  "bs4.*",
+  "loguru",
+  "loguru.*",
+  "pandas",
+  "pandas.*",
+  "pydantic",
+  "pydantic.*",
+  "typer",
+  "yaml",
+]
+ignore_missing_imports = true
+

--- a/src/scraper/base.py
+++ b/src/scraper/base.py
@@ -6,7 +6,7 @@ import time
 from abc import ABC, abstractmethod
 from datetime import datetime
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from loguru import logger
@@ -49,7 +49,8 @@ class BaseScraper(ABC):
         try:
             async with self.session.get(url) as response:
                 if response.status == 200:
-                    return await response.text()
+                    response_text = await response.text()
+                    return cast(str, response_text)
                 else:
                     logger.warning(f"HTTP {response.status} for {url}")
                     return None


### PR DESCRIPTION
## Summary
- allow mypy to ignore missing type information for third-party packages
- cast aiohttp response text to `str` when returning HTML content

## Testing
- ruff format .
- ruff check .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ccbd97216c8326a7ba6fa930f6371b